### PR TITLE
Use env vars for API and WebSocket URLs

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-# REACT_APP_API_KEY=http://api-beeshoes.devopsedu.vn/api
-var api = process.env.REACT_APP_API_KEY;
+REACT_APP_API_URL=https://beeshoes.haimh.tech/api
+REACT_APP_WS_URL=https://beeshoes.haimh.tech/ws
+

--- a/src/AppConfig.js
+++ b/src/AppConfig.js
@@ -1,7 +1,7 @@
 /** @format */
 
 export const AppConfig = {
-  apiUrl: "http://api-beeshoes.devopsedu.vn",
+  apiUrl: process.env.REACT_APP_API_URL,
   routerBase: "",
 };
 

--- a/src/component/employee/DashBoardEmployee.js
+++ b/src/component/employee/DashBoardEmployee.js
@@ -71,7 +71,7 @@ const DashBoardEmployee = ({ children }) => {
   const handleMenuLeave = () => {
     setOpenInfo(false);
   };
-  const socket = new SockJS("http://beeshoes.devopsedu.vn/ws");
+  const socket = new SockJS(process.env.REACT_APP_WS_URL);
   const stompClient = Stomp.over(socket);
 
   const data = useAppSelector(GetNotification);

--- a/src/pages/customer/payment/Payment.js
+++ b/src/pages/customer/payment/Payment.js
@@ -65,7 +65,7 @@ function Payment() {
     { title: " FREE SHIPPING VỚI HÓA ĐƠN TRÊN 2 TRIỆU!" },
   ];
   const [currentTitleIndex, setCurrentTitleIndex] = useState(0);
-  const socket = new SockJS("http://api-beeshoes.devopsedu.vn/ws");
+  const socket = new SockJS(process.env.REACT_APP_WS_URL);
   const stompClient = Stomp.over(socket);
   useEffect(() => {
     console.log(formErrors);

--- a/src/service/AddressService.js
+++ b/src/service/AddressService.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 // Đường dẫn api
-let api = "http://api-beeshoes.devopsedu.vn/admin/address";
+const api = `${process.env.REACT_APP_API_URL}/admin/address`;
 
 var dataUser = [];
 


### PR DESCRIPTION
## Summary
- Add API and WS URLs to `.env`
- Reference `REACT_APP_API_URL` in config and services
- Reference `REACT_APP_WS_URL` for WebSocket connections

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a4960191848331a8b652ff08848e49